### PR TITLE
Improve error handling and allow for automatic retries.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 2.3.5
+script:
+  - bundle exec rspec --force-color --format d

--- a/README.markdown
+++ b/README.markdown
@@ -103,6 +103,26 @@ file = @client.file('/Shared/Documents/LICENSE.txt')
 file.download
 ```
 
+Rate limitations
+-----------
+
+There are rate limitations on a per-token basis in the Egnyte API: per second, and daily quota. 
+
+The library raises a `Egnyte::RateLimitExceededPerSecond` when you go over your alloted rate per second, and raises a `Egnyte::RateLimitExceededQuota` when you go over your alloted daily quota.
+Both exceptions contain a retry_after value.
+
+You can also instantiate the session with the optional keyword variable `retries: 5` e.g.: 
+
+```ruby
+session = Egnyte::Session.new(
+           {access_token: 'secret-token', domain: 'egnyte_domain', username: 'me'}, 
+           :implicit, # or :password for internal apps 
+           0.0, # backoff of 0 makes sense if you are retrying 
+           retries: 5)
+```
+
+
+
 Contributing
 -----------
 

--- a/lib/egnyte/errors.rb
+++ b/lib/egnyte/errors.rb
@@ -27,11 +27,13 @@ module Egnyte
   class OAuthPasswordRequired < StandardError; end
   class MissingAttribute < EgnyteError; end
 
-  class RateLimitExceededQPS < EgnyteError
+  class RateLimitExceeded < EgnyteError
     attr_reader :retry_after
     def initialize(data, retry_after)
       super(data)
       @retry_after = retry_after
     end
   end
+  class RateLimitExceededPerSecond < RateLimitExceeded ; end
+  class RateLimitExceededQuota < RateLimitExceeded ; end
 end

--- a/lib/egnyte/errors.rb
+++ b/lib/egnyte/errors.rb
@@ -1,6 +1,7 @@
-module Egnyte 
+module Egnyte
   class EgnyteError < StandardError
     def initialize(data)
+      super(data.to_s)
       @data = data
     end
 

--- a/lib/egnyte/errors.rb
+++ b/lib/egnyte/errors.rb
@@ -26,4 +26,12 @@ module Egnyte
   class OAuthUsernameRequired < StandardError; end
   class OAuthPasswordRequired < StandardError; end
   class MissingAttribute < EgnyteError; end
+
+  class RateLimitExceededQPS < EgnyteError
+    attr_reader :retry_after
+    def initialize(data, retry_after)
+      super(data)
+      @retry_after = retry_after
+    end
+  end
 end

--- a/lib/egnyte/session.rb
+++ b/lib/egnyte/session.rb
@@ -176,7 +176,9 @@ module Egnyte
       when 403
         case response.header['X-Mashery-Error-Code']
         when "ERR_403_DEVELOPER_OVER_QPS"
-          raise RateLimitExceededQPS.new(response_body, response.header['Retry-After']&.to_i)
+          raise RateLimitExceededPerSecond.new(response_body, response.header['Retry-After']&.to_i)
+        when "ERR_403_DEVELOPER_OVER_RATE"
+          raise RateLimitExceededQuota.new(response_body, response.header['Retry-After']&.to_i)
         else
           raise InsufficientPermissions.new(response_body)
         end

--- a/lib/egnyte/session.rb
+++ b/lib/egnyte/session.rb
@@ -49,7 +49,7 @@ module Egnyte
         end
         @username = info["username"] unless @username
       end
-      
+
     end
 
     def info
@@ -190,7 +190,7 @@ module Egnyte
     def parse_response_body(body)
       JSON.parse(body)
     rescue
-      {}
+      {original_body: body} # return original_body as a json hash if unparseable
     end
 
   end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -53,4 +53,51 @@ describe Egnyte::EgnyteError do
     end
   end
 
+  context "with a  non json error" do
+    before do
+      stub_request(:get, "https://test.egnyte.com/pubapi/v1/fs/Shared/example.txt")
+        .to_return(:body => "#{error_message} which doesn't look like JSON!", :status => 400)
+    end
+    let(:error_message) {"Something new in sandwitches"}
+    it "raises expected error class" do
+      expect {subject}.to raise_error(Egnyte::BadRequest)
+    end
+    it "raises expected error with message " do
+      expect {subject}.to raise_error /#{error_message}/
+    end
+  end
+
+  context "with a standard 403" do
+    before do
+      stub_request(:get, "https://test.egnyte.com/pubapi/v1/fs/Shared/example.txt")
+        .to_return(:body => "#{error_message} which doesn't look like JSON!", :status => 403)
+    end
+    let(:error_message) {"Something new in sandwitches"}
+    it "raises expected error class" do
+      expect {subject}.to raise_error(Egnyte::InsufficientPermissions)
+    end
+    it "raises expected error with message " do
+      expect {subject}.to raise_error /#{error_message}/
+    end
+  end
+
+  context "with a 403 indicating oer QPS" do
+    before do
+      stub_request(:get, "https://test.egnyte.com/pubapi/v1/fs/Shared/example.txt")
+        .to_return(:body => "#{error_message} which doesn't look like JSON!", :status => 403,
+          headers: { 'X-Mashery-Error-Code' => 'ERR_403_DEVELOPER_OVER_QPS', 'Retry-After' => 1 })
+    end
+
+    let(:error_message) {"Something new in sandwitches"}
+    it "raises expected error class" do
+      expect {subject}.to raise_error(Egnyte::RateLimitExceededQPS)
+    end
+
+    it "returns correct retry_after" do
+      expect {subject}.to raise_error(Egnyte::RateLimitExceededQPS) do |e|
+        expect(e.retry_after).to eq(1)
+      end
+    end
+  end
+
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,56 @@
+#encoding: UTF-8
+
+require 'spec_helper'
+
+describe Egnyte::EgnyteError do
+  before(:each) do
+    session = Egnyte::Session.new({
+      key: 'api_key',
+      domain: 'test',
+      access_token: 'access_token'
+    }, :implicit, 0.0)
+    @client = Egnyte::Client.new(session)
+  end
+
+  subject {@client.file('/Shared/example.txt')}
+
+  context "status: 200" do
+    before do
+      stub_request(:get, "https://test.egnyte.com/pubapi/v1/fs/Shared/example.txt")
+        .to_return(:body => File.read('./spec/fixtures/list_file.json'), :status => 200)
+    end
+    it "works" do
+      expect {subject}.not_to raise_error
+    end
+  end
+
+  let(:error_message) {"Something new in sandwiches"}
+  context "with a json error" do
+    before do
+      stub_request(:get, "https://test.egnyte.com/pubapi/v1/fs/Shared/example.txt")
+        .to_return(:body => { "Errors": [{ "description": error_message, "code": "400" }] }.to_json, :status =>
+          400)
+    end
+    it "raises expected error class" do
+      expect {subject}.to raise_error(Egnyte::BadRequest)
+    end
+    it "raises expected error with message " do
+      expect {subject}.to raise_error /#{error_message}/
+    end
+  end
+
+  context "with a  non json error" do
+    before do
+      stub_request(:get, "https://test.egnyte.com/pubapi/v1/fs/Shared/example.txt")
+        .to_return(:body => "#{error_message} which doesn't look like JSON!", :status => 400)
+    end
+    let(:error_message) {"Something new in sandwitches"}
+    it "raises expected error class" do
+      expect {subject}.to raise_error(Egnyte::BadRequest)
+    end
+    it "raises expected error with message " do
+      expect {subject}.to raise_error /#{error_message}/
+    end
+  end
+
+end

--- a/spec/file_spec.rb
+++ b/spec/file_spec.rb
@@ -4,9 +4,6 @@ require 'spec_helper'
 
 describe Egnyte::File do
   before(:each) do
-    stub_request(:get, "https://test.egnyte.com/pubapi/v1/userinfo").
-             with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'User-Agent'=>'Ruby'}).
-             to_return(:status => 200, :body => "", :headers => {})
     session = Egnyte::Session.new({
       key: 'api_key',
       domain: 'test',

--- a/spec/folder_spec.rb
+++ b/spec/folder_spec.rb
@@ -4,9 +4,6 @@ require 'spec_helper'
 
 describe Egnyte::Folder do
   before(:each) do
-    stub_request(:get, "https://test.egnyte.com/pubapi/v1/userinfo").
-             with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'User-Agent'=>'Ruby'}).
-             to_return(:status => 200, :body => "", :headers => {})
     @session = Egnyte::Session.new({
       key: 'api_key',
       domain: 'test',

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -7,9 +7,6 @@ describe Egnyte::Group do
       :displayName => "Test with members",
       :members => [9967960066, 9967960068]
     }
-    stub_request(:get, "https://test.egnyte.com/pubapi/v1/userinfo").
-             with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'User-Agent'=>'Ruby'}).
-             to_return(:status => 200, :body => "", :headers => {})
     @session = Egnyte::Session.new({
       key: 'api_key',
       domain: 'test',
@@ -160,7 +157,7 @@ describe Egnyte::Group do
       expect(Egnyte::User).to receive(:delete).and_return({})
       Egnyte::User.delete(@session, "5ef70bb0-edeb-4fcb-86d4-e1e1a0b6c9dc")
     end
-    
+
   end
 
 end

--- a/spec/links_spec.rb
+++ b/spec/links_spec.rb
@@ -15,9 +15,6 @@ describe Egnyte::Link do
       type: 'file',
       accessibility: 'Anyone'
     }
-    stub_request(:get, "https://test.egnyte.com/pubapi/v1/userinfo").
-             with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'User-Agent'=>'Ruby'}).
-             to_return(:status => 200, :body => "", :headers => {})
     @session = Egnyte::Session.new({
       key: 'api_key',
       domain: 'test',
@@ -138,7 +135,7 @@ describe Egnyte::Link do
       expect(Egnyte::User).to receive(:delete)
       Egnyte::User.delete(@session, 'jFmtRccgU0')
     end
-    
+
   end
 
   describe "#to_json" do

--- a/spec/permissions_spec.rb
+++ b/spec/permissions_spec.rb
@@ -12,9 +12,9 @@ describe Egnyte::Permission do
         "groups" => { "Test Group" => "Editor" }
     }
     @invalid_permission_hash = {
-        "blah" => { 
-          "david" => "Owner", 
-          "dpfeffer" => "Editor" 
+        "blah" => {
+          "david" => "Owner",
+          "dpfeffer" => "Editor"
         }
     }
     @lowercase_permission_hash = {
@@ -32,9 +32,6 @@ describe Egnyte::Permission do
         "groups" => { "Test Group" => "perms" }
     }
     @valid_permission_structure_from_api = JSON.parse(File.read('./spec/fixtures/permission/permission_list.json'))
-    stub_request(:get, "https://test.egnyte.com/pubapi/v1/userinfo").
-             with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'User-Agent'=>'Ruby'}).
-             to_return(:status => 200, :body => "", :headers => {})
     @session = Egnyte::Session.new({
       key: 'api_key',
       domain: 'test',
@@ -52,7 +49,7 @@ describe Egnyte::Permission do
     end
 
     it 'raises an error if it does not have valid fields' do
-      expect {Egnyte::Permission.new(@invalid_permission_hash)}.to raise_error( Egnyte::InvalidParameters ) 
+      expect {Egnyte::Permission.new(@invalid_permission_hash)}.to raise_error( Egnyte::InvalidParameters )
     end
 
     it 'drops invalid permission levels' do

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -17,9 +17,6 @@ describe Egnyte::User do
       :active => true,
       :sendInvite => true
     }
-    stub_request(:get, "https://test.egnyte.com/pubapi/v1/userinfo").
-             with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer access_token', 'User-Agent'=>'Ruby'}).
-             to_return(:status => 200, :body => "", :headers => {})
     @session = Egnyte::Session.new({
       key: 'api_key',
       domain: 'test',
@@ -178,7 +175,7 @@ describe Egnyte::User do
       expect(Egnyte::User).to receive(:delete).and_return({})
       Egnyte::User.delete(@session, 12408258604)
     end
-    
+
   end
 
   describe "#User::links" do
@@ -192,7 +189,7 @@ describe Egnyte::User do
         .to_return(:status => 200, :body => File.read('./spec/fixtures/link/link_list.json'), :headers => {})
       Egnyte::User.links(@session, 12408258604)
     end
-    
+
   end
 
   describe "#User::permissions" do
@@ -206,7 +203,7 @@ describe Egnyte::User do
         .to_return(:status => 200, :body => File.read('./spec/fixtures/link/link_list.json'), :headers => {})
       Egnyte::User.links(@session, 12408258604)
     end
-    
+
   end
 
 end


### PR DESCRIPTION
* Exceptions now include the response given by Egnyte (may be useful for debugging)
* New exceptions for `RateLimitExceededPerSecond` and `RateLimitExceededQuota` which include `retry_after` (previously these were reported as `InsufficientPermissions`)
* optional parameter for `Session` for retries, which allows for a number of retries after sleep when `RateLimitExceededPerSecond` occurs

Also:

* travis CI working (on this branch -- will need set up at travis-ci.org

NB:  This PR assumes ruby 2.0+ (think should be moved to something like 2.3+), and is testing on 2.3.5